### PR TITLE
Fog parameter function corrections

### DIFF
--- a/xgu.h
+++ b/xgu.h
@@ -527,18 +527,12 @@ uint32_t* xgu_set_fog_color(uint32_t* p, uint32_t color) {
 }
 
 XGU_API
-uint32_t* xgu_set_fog_start(uint32_t* p, float start) {
-    return push_command_float(p, NV097_SET_FOG_PARAMS, start);
-}
-
-XGU_API
-uint32_t* xgu_set_fog_end(uint32_t* p, float end) {
-    return push_command_float(p, NV097_SET_FOG_PARAMS + 4, end);
-}
-
-XGU_API
-uint32_t* xgu_set_fog_density(uint32_t* p, float density) {
-    return push_command_float(p, NV097_SET_FOG_PARAMS + 8, density);
+uint32_t* xgu_set_fog_params(uint32_t* p, float bias, float scale) {
+    p = push_command(p, NV097_SET_FOG_PARAMS, 3);
+    p = push_float(p, bias);
+    p = push_float(p, scale);
+    p = push_float(p, 0.0f);
+    return p;
 }
 
 XGU_API


### PR DESCRIPTION
As JayFoxRox [rightly pointed out](https://github.com/dracc/nxdk/pull/4#discussion_r457249246), the fog param functions which I added in a previous PR were incorrect.

This PR replaces these wrong functions with a more accurate and correct function, which has already been tested with a fixed-function radial/exponential fog configuration:

![radial exponential fog](https://cdn.discordapp.com/attachments/428359408204906497/779294182438862859/unknown.png)

The first and second parameters turn out to be, in fact, bias and scale, and are both certain [pre-calculated values](https://github.com/mborgerson/xemu/blob/02157b0958d909f4670cdfc30819b7cc71bb708d/hw/xbox/nv2a/shaders.c#L747) depending on whichever fog mode is used.
The third paramater appears to be unused, so is just set to 0.0f.