### PR TITLE
Add a depth range utility function

### DIFF
--- a/nv2a_regs.h
+++ b/nv2a_regs.h
@@ -803,6 +803,7 @@
 #   define NV097_SET_COMBINER_SPECULAR_FOG_CW1                0x0000028C
 #   define NV097_SET_CONTROL0                                 0x00000290
 #       define NV097_SET_CONTROL0_STENCIL_WRITE_ENABLE            (1 << 0)
+#       define NV097_SET_CONTROL0_TEXTUREPERSPECTIVE              (1 << 5)
 #       define NV097_SET_CONTROL0_Z_FORMAT                        (1 << 12)
 #       define NV097_SET_CONTROL0_Z_PERSPECTIVE_ENABLE            (1 << 16)
 #   define NV097_SET_FOG_MODE                                 0x0000029C

--- a/xgux.h
+++ b/xgux.h
@@ -91,6 +91,20 @@ void xgux_set_clear_rect(unsigned int x, unsigned int y,
     pb_end(p);
 }
 
+#define NV097_SET_CONTROL0_TEXTUREPERSPECTIVE 0x100000
+
+XGUX_API
+void xgux_set_depth_range(float znear, float zfar) {
+    uint32_t *p = pb_begin();
+    uint32_t control0 = NV097_SET_CONTROL0_TEXTUREPERSPECTIVE | NV097_SET_CONTROL0_STENCIL_WRITE_ENABLE;
+    p = push_command_parameter(p, NV097_SET_CONTROL0, control0);
+    p = push_command_parameter(p, NV097_SET_ZMIN_MAX_CONTROL, 1);
+    p = push_command_parameter(p, NV097_SET_COMPRESS_ZBUFFER_EN, 1);
+    p = xgu_set_clip_min(p, znear);
+    p = xgu_set_clip_max(p, zfar);
+    pb_end(p);
+}
+
 XGUX_API
 void xgux_set_attrib_pointer(XguVertexArray index, XguVertexArrayType format, unsigned int size, unsigned int stride, const void* data) {
     uint32_t *p = pb_begin();

--- a/xgux.h
+++ b/xgux.h
@@ -91,8 +91,6 @@ void xgux_set_clear_rect(unsigned int x, unsigned int y,
     pb_end(p);
 }
 
-#define NV097_SET_CONTROL0_TEXTUREPERSPECTIVE 0x100000
-
 XGUX_API
 void xgux_set_depth_range(float znear, float zfar) {
     uint32_t *p = pb_begin();


### PR DESCRIPTION
This adds `xgux_set_depth_range` to XGUX, a utility function to clamp the zbuffer to a particular set range.
This fixes depth and clipping issues when drawing multiple meshes.