### PR TITLE
Fix NV097_SET_CONTROL0_TEXTUREPERSPECTIVE value

### DIFF
--- a/nv2a_regs.h
+++ b/nv2a_regs.h
@@ -803,9 +803,9 @@
 #   define NV097_SET_COMBINER_SPECULAR_FOG_CW1                0x0000028C
 #   define NV097_SET_CONTROL0                                 0x00000290
 #       define NV097_SET_CONTROL0_STENCIL_WRITE_ENABLE            (1 << 0)
-#       define NV097_SET_CONTROL0_TEXTUREPERSPECTIVE              (1 << 5)
 #       define NV097_SET_CONTROL0_Z_FORMAT                        (1 << 12)
 #       define NV097_SET_CONTROL0_Z_PERSPECTIVE_ENABLE            (1 << 16)
+#       define NV097_SET_CONTROL0_TEXTUREPERSPECTIVE              (1 << 20)
 #   define NV097_SET_FOG_MODE                                 0x0000029C
 #       define NV097_SET_FOG_MODE_V_LINEAR                        0x2601
 #       define NV097_SET_FOG_MODE_V_EXP                           0x800


### PR DESCRIPTION
I'm so sorry; I made a little miscalculation in my previous pull request in regards to the value of NV097_SET_CONTROL0_TEXTUREPERSPECTIVE!

It should have been (1 << 20) and not (1 << 5).

This was causing a GPU crash on real hardware, but I can confirm that I have properly tested this fix and everything is working again as it should.